### PR TITLE
Fixed table iteration error when you die

### DIFF
--- a/data/tdmp/TDMP/players.lua
+++ b/data/tdmp/TDMP/players.lua
@@ -404,11 +404,13 @@ function PlayerBodiesPlayerTick(ply)
 				end
 			end
 
-			for k, v in pairs((PlayerBodies[steamid] or {}).Parts) do
-				Delete(v.hnd)
+			if (PlayerBodies[steamid] and PlayerBodies[steamid].Parts) then
+				for k, v in pairs(PlayerBodies[steamid].Parts) do
+					Delete(v.hnd)
+				end
 			end
 
-			if (PlayerBodies[steamid] or {}).Flashlight then
+			if (PlayerBodies[steamid] and PlayerBodies[steamid].Flashlight) then
 				for i, v in ipairs(PlayerBodies[steamid].Flashlight) do
 					Delete(v)
 				end


### PR DESCRIPTION
If you die with **Player corpses** set to **OFF** then you'll most likely get this error: `"data/tdmp/TDMP/players.lua"]:407: bad argument #1 to 'pairs' (table expected, got nil)`

I simply fixed it by checking if `.Parts` exists in the PlayerBody before iterating over it.