### PR TITLE
Added functions to show player in game map

### DIFF
--- a/data/tdmp/TDMP/players.lua
+++ b/data/tdmp/TDMP/players.lua
@@ -98,6 +98,8 @@ function PlayerBody(steamid, playermodel, force)
 			local lTr = TransformToLocalTransform(PlayerBody.Hip, tr)
 
 			if HasTag(ent, "playerBody_torso") then
+				SetTag(ent, "map")
+				SetDescription(ent, "Player "..(Player(steamid).nick)..";"..(Player(steamid).nick))
 				PlayerBody.Parts.Torso = {
 					hnd = ent,
 					localTransform = lTr


### PR DESCRIPTION
Set player's ragdoll body with tag `map` and formatted description to allow vanilla game's map to show player as a blue dot
![image](https://user-images.githubusercontent.com/70589524/210117307-fffcec6a-03ef-4d28-b314-2ffd2b227c74.png)
